### PR TITLE
fix: remove revision from qwik assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,21 @@
 {
   "name": "@qwikdev/pwa",
+  "type": "module",
   "version": "0.0.1",
-  "description": "Create a reusable Qwik component library",
-  "main": "./dist/index.qwik.mjs",
-  "qwik": "./dist/index.qwik.mjs",
-  "types": "./lib-types/index.d.ts",
+  "packageManager": "pnpm@8.12.1",
+  "description": "Qwik PWA",
+  "homepage": "https://github.com/QwikDev/pwa#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QwikDev/pwa.git"
+  },
+  "bugs": "https://github.com/QwikDev/pwa/issues",
+  "keywords": [
+    "qwik",
+    "pwa",
+    "workbox",
+    "service worker"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.qwik.mjs",
@@ -22,6 +33,9 @@
       "types": "./lib-types/icons-entry.d.ts"
     }
   },
+  "main": "./dist/index.qwik.mjs",
+  "qwik": "./dist/index.qwik.mjs",
+  "types": "./lib-types/index.d.ts",
   "files": [
     "dist",
     "lib-types"
@@ -29,8 +43,6 @@
   "engines": {
     "node": ">=15.0.0"
   },
-  "private": false,
-  "type": "module",
   "scripts": {
     "build": "qwik build",
     "build.lib.watch": "vite build --mode lib --watch",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -16,13 +16,10 @@ export const assets = [...publicDirAssets, ...emittedAssets];
 export { routes };
 
 function urlsToEntries(urls: string[], hash: string): PrecacheEntry[] {
-  const matcher = /^build\/q-([a-f0-9]{8})\./;
+  const matcher = /^build\/q-/;
   return urls.map((url) => {
     const match = url.match(matcher);
-    return {
-      url,
-      revision: `${match ? match[1] : hash}`,
-    };
+    return match ? { url } : { url, revision: hash };
   });
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,8 @@ import { builtinModules } from "node:module";
 // import tsconfigPaths from "vite-tsconfig-paths";
 
 const { dependencies = {}, peerDependencies = {} } = pkg as any;
-const makeRegex = (dep) => new RegExp(`^${dep}(/.*)?$`);
-const excludeAll = (obj) => Object.keys(obj).map(makeRegex);
+const makeRegex = (dep: string) => new RegExp(`^${dep}(/.*)?$`);
+const excludeAll = (obj: any) => Object.keys(obj).map(makeRegex);
 
 export default defineConfig({
   build: {


### PR DESCRIPTION
This PR also includes:
- add some missing types in vite config file
- added some entries in the package.json
- added package manager in package.json (8.12.1)

Any qwik asset shouldn't have a revision, it is already versioned:

![image](https://github.com/QwikDev/pwa/assets/6311119/46829f35-1766-4031-8d1e-edd3272c1fa2)


We should review the build, there are 3 builds, and the dts files should go to the dist folder:

![image](https://github.com/QwikDev/pwa/assets/6311119/909bc963-12a5-4f18-8b26-06465103b816)
