### PR TITLE
fix: installable PWA

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ setupPwa("prompt");
 + "theme_color": "#fff",
 ```
 
+For more information, check the following pages:
+- [PWA Minimal Icons Requirements](https://vite-pwa-org.netlify.app/assets-generator/#pwa-minimal-icons-requirements)
+- [PWA Minimal Requirements](https://vite-pwa-org.netlify.app/guide/pwa-minimal-requirements.html)
+- [Add a web app manifest](https://web.dev/articles/add-manifest)
+
 `src/components/router-head/router-head.tsx`:
 
 ```tsx
@@ -81,8 +86,6 @@ export const RouterHead = component$(() => {
 ```
 
 Make sure you remove the `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` line in your router-head file.
-
-You will need to add `@qwilkdev/pwa` to your `tsconfig.json` file in the `compilerOptions.types` option.
 
 Now your application is PWA-friendly.
 

--- a/README.md
+++ b/README.md
@@ -33,16 +33,34 @@ export default defineConfig(() => {
 
 `src/routes/service-worker.ts`:
 
+```diff
+import { setupServiceWorker } from "@builder.io/qwik-city/service-worker";
+import { setupPwa } from "@qwikdev/pwa/sw";
+
+setupServiceWorker();
+
++setupPwa();
+
+- addEventListener("install", () => self.skipWaiting());
+
+- addEventListener("activate", () => self.clients.claim());
+
+- declare const self: ServiceWorkerGlobalScope;
+```
+
+By default, your application will be auto-updated when there's a new version of the service worker available and it is installed: in a future version, you will be able to customize this behavior to use `prompt` for update:
 ```ts
 import { setupServiceWorker } from "@builder.io/qwik-city/service-worker";
 import { setupPwa } from "@qwikdev/pwa/sw";
 
 setupServiceWorker();
-setupPwa();
+setupPwa("prompt");
+```
 
-addEventListener("install", () => self.skipWaiting());
-
-addEventListener("activate", () => self.clients.claim());
+`public/manifest.json`:
+```diff
+"background_color": "#fff",
++ "theme_color": "#fff",
 ```
 
 `src/components/router-head/router-head.tsx`:
@@ -64,7 +82,7 @@ export const RouterHead = component$(() => {
 
 Make sure you remove the `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` line in your router-head file.
 
-You will need to add `@qwilkdev/pwa/head` to your `tsconfig.json` file in the `compilerOptions.types` option.
+You will need to add `@qwilkdev/pwa` to your `tsconfig.json` file in the `compilerOptions.types` option.
 
 Now your application is PWA-friendly.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,11 @@
 # TODO LIST
 
 - [ ] fix eslint/prettier: it is a pain to have to include the type in static imports
-- [ ] fix workbox runtime warnings: there are a few workbox runtime warnings in the example that should be checked (build/q-*.[webp|css])
+- [x] fix workbox runtime warnings: there are a few workbox runtime warnings in the example that should be checked (build/q-*.[webp|css])
 - [ ] feat add prompt for update strategy: the user can lost form data if filling a form when the update is triggered
 - [ ] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example
 - [x] don't inject web manifest icons when present in the manifest
+
+## Fix workbox runtime warnings
+
+We must include the revision with `null` value in the precache manifest for `build/q-**` assets.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO LIST
+
+- [ ] fix eslint/prettier: it is a pain to have to include the type in static imports
+- [ ] fix workbox runtime warnings: there are a few workbox runtime warnings in the example that should be checked (build/q-*.[webp|css])
+- [ ] feat add prompt for update strategy: the user can lost form data if filling a form when the update is triggered
+- [ ] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - [ ] fix eslint/prettier: it is a pain to have to include the type in static imports
 - [x] fix workbox runtime warnings: there are a few workbox runtime warnings in the example that should be checked (build/q-*.[webp|css])
 - [ ] feat add prompt for update strategy: the user can lost form data if filling a form when the update is triggered
-- [ ] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example
+- [x] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example
 - [x] don't inject web manifest icons when present in the manifest
 - [x] include id and scope in the web manifest when missing
 - [x] warn when missing `theme_color` in the web manifest

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,8 @@
 - [ ] feat add prompt for update strategy: the user can lost form data if filling a form when the update is triggered
 - [ ] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example
 - [x] don't inject web manifest icons when present in the manifest
+- [x] include id and scope in the web manifest when missing
+- [x] warn when missing `theme_color` in the web manifest
 
 ## Fix workbox runtime warnings
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - [ ] fix workbox runtime warnings: there are a few workbox runtime warnings in the example that should be checked (build/q-*.[webp|css])
 - [ ] feat add prompt for update strategy: the user can lost form data if filling a form when the update is triggered
 - [ ] test custom pwa assets generator config file: on change the app should receive a page reload (no dev server restart), maybe with a new example
+- [x] don't inject web manifest icons when present in the manifest

--- a/example/package.json
+++ b/example/package.json
@@ -16,6 +16,7 @@
     "preview": "qwik build preview && vite preview",
     "start": "vite --open --mode ssr",
     "dev": "vite --mode ssr",
+    "dev.custom": "CUSTOM_CONFIG=true vite --mode ssr",
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check ."

--- a/example/public/manifest.json
+++ b/example/public/manifest.json
@@ -5,6 +5,7 @@
   "start_url": ".",
   "display": "standalone",
   "background_color": "#fff",
+  "theme_color": "#fff",
   "description": "A Qwik project app.",
   "screenshots": [
     {

--- a/example/pwa-assets.config.ts
+++ b/example/pwa-assets.config.ts
@@ -1,0 +1,12 @@
+import {
+  defineConfig,
+  minimal2023Preset as preset,
+} from "@vite-pwa/assets-generator/config";
+
+export default defineConfig({
+  headLinkOptions: {
+    preset: "2023",
+  },
+  preset,
+  images: ["public/favicon.svg"],
+});

--- a/example/src/routes/service-worker.ts
+++ b/example/src/routes/service-worker.ts
@@ -3,7 +3,3 @@ import { setupPwa } from "@qwikdev/pwa/sw";
 
 setupServiceWorker();
 setupPwa();
-
-addEventListener("install", () => self.skipWaiting());
-
-addEventListener("activate", () => self.clients.claim());

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -16,10 +16,9 @@
     "isolatedModules": true,
     "outDir": "tmp",
     "noEmit": true,
-    "types": ["node", "vite/client"],
+    "types": ["node", "vite/client", "@qwikdev/pwa"],
     "paths": {
-      "~/*": ["./src/*"],
-      "@qwikdev/pwa/*": ["../lib-types/*"]
+      "~/*": ["./src/*"]
     }
   },
   "files": ["./.eslintrc.cjs"],

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -4,6 +4,8 @@ import { qwikCity } from "@builder.io/qwik-city/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { qwikPwa } from "@qwikdev/pwa";
 
+const config = process.env.CUSTOM_CONFIG === "true"
+
 export default defineConfig(() => {
   return {
     define: {
@@ -14,7 +16,7 @@ export default defineConfig(() => {
       qwikCity(),
       qwikVite(),
       tsconfigPaths(),
-      qwikPwa()
+      qwikPwa({ config })
     ],
     preview: {
       headers: {

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from "vite";
 import { qwikVite } from "@builder.io/qwik/optimizer";
 import { qwikCity } from "@builder.io/qwik-city/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { qwikPwa } from "@qwikdev/pwa";
+import { type PWAOptions, qwikPwa } from "@qwikdev/pwa";
 
-const config = process.env.CUSTOM_CONFIG === "true"
+const config: PWAOptions | undefined = process.env.CUSTOM_CONFIG === "true"
+ ? { config: true }
+    : undefined;
 
 export default defineConfig(() => {
   return {
@@ -16,7 +18,7 @@ export default defineConfig(() => {
       qwikCity(),
       qwikVite(),
       tsconfigPaths(),
-      qwikPwa({ config })
+      qwikPwa(config)
     ],
     preview: {
       headers: {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@qwikdev/pwa",
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "pnpm@8.12.1",
+  "packageManager": "pnpm@8.13.1",
   "description": "Qwik PWA",
   "homepage": "https://github.com/QwikDev/pwa#readme",
   "repository": {
@@ -105,7 +105,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.3",
     "ultrahtml": "^1.5.2",
     "undici": "^5.26.0",
     "vite": "^4.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,10 +29,10 @@ importers:
         version: 20.9.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.7.5
-        version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.2)
+        version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ^6.7.5
-        version: 6.12.0(eslint@8.54.0)(typescript@5.3.2)
+        version: 6.12.0(eslint@8.54.0)(typescript@5.3.3)
       eslint:
         specifier: ^8.51.0
         version: 8.54.0
@@ -41,7 +41,7 @@ importers:
         version: 1.2.19(eslint@8.54.0)
       np:
         specifier: ^8.0.4
-        version: 8.0.4(typescript@5.3.2)
+        version: 8.0.4(typescript@5.3.3)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -52,8 +52,8 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       typescript:
-        specifier: ^5.2.2
-        version: 5.3.2
+        specifier: ^5.3.3
+        version: 5.3.3
       ultrahtml:
         specifier: ^1.5.2
         version: 1.5.2
@@ -65,7 +65,7 @@ importers:
         version: 4.5.0(@types/node@20.9.4)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.2.1(typescript@5.3.2)(vite@4.5.0)
+        version: 4.2.1(typescript@5.3.3)(vite@4.5.0)
       workbox-precaching:
         specifier: ^7.0.0
         version: 7.0.0
@@ -754,6 +754,35 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.54.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.3.3)
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/type-utils': 6.12.0(eslint@8.54.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.12.0
+      debug: 4.3.4
+      eslint: 8.54.0
+      graphemer: 1.4.0
+      ignore: 5.3.0
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -771,6 +800,27 @@ packages:
       debug: 4.3.4
       eslint: 8.54.0
       typescript: 5.3.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.3)
+      '@typescript-eslint/visitor-keys': 6.12.0
+      debug: 4.3.4
+      eslint: 8.54.0
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -803,6 +853,26 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/type-utils@6.12.0(eslint@8.54.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.3.3)
+      debug: 4.3.4
+      eslint: 8.54.0
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types@6.12.0:
     resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -829,6 +899,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@6.12.0(typescript@5.3.3):
+    resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/visitor-keys': 6.12.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -841,6 +932,25 @@ packages:
       '@typescript-eslint/scope-manager': 6.12.0
       '@typescript-eslint/types': 6.12.0
       '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.2)
+      eslint: 8.54.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.6
+      '@typescript-eslint/scope-manager': 6.12.0
+      '@typescript-eslint/types': 6.12.0
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.3.3)
       eslint: 8.54.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -1428,7 +1538,7 @@ packages:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  /cosmiconfig@8.3.6(typescript@5.3.2):
+  /cosmiconfig@8.3.6(typescript@5.3.3):
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -1441,7 +1551,7 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      typescript: 5.3.2
+      typescript: 5.3.3
     dev: true
 
   /cross-spawn@6.0.5:
@@ -3826,13 +3936,13 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
-  /np@8.0.4(typescript@5.3.2):
+  /np@8.0.4(typescript@5.3.3):
     resolution: {integrity: sha512-a4s1yESHcIwsrk/oaTekfbhb1R/2z2yyfVLX6Atl54w/9+QR01qeYyK3vMWgJ0UY+kYsGzQXausgvUX0pkmIMg==}
     engines: {git: '>=2.11.0', node: '>=16.6.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
     hasBin: true
     dependencies:
       chalk: 5.3.0
-      cosmiconfig: 8.3.6(typescript@5.3.2)
+      cosmiconfig: 8.3.6(typescript@5.3.3)
       del: 7.1.0
       escape-goat: 4.0.0
       escape-string-regexp: 5.0.0
@@ -5118,6 +5228,15 @@ packages:
       typescript: 5.3.2
     dev: true
 
+  /ts-api-utils@1.0.3(typescript@5.3.3):
+    resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.3.3
+    dev: true
+
   /tsconfck@2.1.2(typescript@5.3.2):
     resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
     engines: {node: ^14.13.1 || ^16 || >=18}
@@ -5129,6 +5248,19 @@ packages:
         optional: true
     dependencies:
       typescript: 5.3.2
+    dev: true
+
+  /tsconfck@2.1.2(typescript@5.3.3):
+    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.3.3
     dev: true
 
   /tslib@1.14.1:
@@ -5239,6 +5371,12 @@ packages:
 
   /typescript@5.3.2:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -5468,6 +5606,23 @@ packages:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 2.1.2(typescript@5.3.2)
+      vite: 4.5.0(@types/node@20.9.4)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /vite-tsconfig-paths@4.2.1(typescript@5.3.3)(vite@4.5.0):
+    resolution: {integrity: sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 2.1.2(typescript@5.3.3)
       vite: 4.5.0(@types/node@20.9.4)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
-  - 'example'
-  - './'
+  - example

--- a/src/assets/config.ts
+++ b/src/assets/config.ts
@@ -79,7 +79,7 @@ export async function loadAssetsGeneratorContext(
 
   const useImage = Array.isArray(images) ? images[0] : images;
   const imageFile = resolve(root, useImage);
-  const publicDir = resolve(root, ctx.viteConfig.publicDir ?? "public");
+  const publicDir = resolve(root, ctx.publicDir);
   const outDir = ctx.clientOutBaseDir;
   const imageName = relative(publicDir, imageFile);
   const imageOutDir = dirname(resolve(outDir, imageName));

--- a/src/assets/config.ts
+++ b/src/assets/config.ts
@@ -4,6 +4,7 @@ import type { AssetsGeneratorContext, ResolvedPWAAsset } from "./types";
 import { basename, dirname, relative, resolve } from "node:path";
 import { instructions } from "@vite-pwa/assets-generator/api/instructions";
 import { readFile } from "node:fs/promises";
+import { overrideWebManifestIcons } from "./manifest";
 
 async function loadConfiguration(root: string, ctx: QwikPWAContext) {
   if (ctx.options.config === false) {
@@ -105,8 +106,12 @@ export async function loadAssetsGeneratorContext(
     includeWebManifest,
     includeHtmlHeadLinks,
     includeThemeColor,
-    overrideManifestIcons,
+    overrideManifestIcons: useOverrideManifestIcons,
   } = ctx.options;
+
+  const overrideManifestIcons = useOverrideManifestIcons
+    ? await overrideWebManifestIcons(resolvedWebManifestFile)
+    : false;
 
   if (assetContext === undefined) {
     return {

--- a/src/assets/dev.ts
+++ b/src/assets/dev.ts
@@ -15,8 +15,6 @@ export async function findPWAAsset(
   }
 
   if (path === ctx.webManifestUrl) {
-    if (!ctx.options.overrideManifestIcons) return;
-
     const manifest = await readManifestFile(ctx);
     if (!manifest) return;
 
@@ -24,6 +22,7 @@ export async function findPWAAsset(
       path,
       mimeType: "application/manifest+json",
       buffer: injectWebManifestIcons(
+        ctx,
         manifest,
         assetsContext.assetsInstructions,
       ),
@@ -48,7 +47,7 @@ export async function findPWAAsset(
       path,
       mimeType: iconAsset.mimeType,
       buffer: iconAsset.buffer(),
-      lastModified: assetsContext.lastModified,
+      lastModified: Date.now(),
       age: 0,
     } satisfies ResolvedPWAAsset;
     assetsContext.cache.set(path, resolved);
@@ -63,10 +62,6 @@ export async function checkHotUpdate(
 ) {
   // watch web manifest changes
   if (file === assetsContext.resolvedWebManifestFile) {
-    // when no web manifest icons injection,
-    // just let Vite do its work
-    // will reload the page or send hmr in src/root.tsx
-    if (!ctx.options.overrideManifestIcons) return false;
     assetsContext.cache.delete(ctx.webManifestUrl);
     return true;
   }

--- a/src/assets/dev.ts
+++ b/src/assets/dev.ts
@@ -1,4 +1,4 @@
-import { injectWebManifestIcons, readManifestFile } from "./manifest";
+import { injectWebManifestEntries, readManifestFile } from "./manifest";
 import type { AssetsGeneratorContext, ResolvedPWAAsset } from "./types";
 import type { QwikPWAContext } from "../context";
 import { loadAssetsGeneratorContext } from "./config";
@@ -21,7 +21,7 @@ export async function findPWAAsset(
     resolved = {
       path,
       mimeType: "application/manifest+json",
-      buffer: injectWebManifestIcons(
+      buffer: injectWebManifestEntries(
         ctx,
         manifest,
         assetsContext.assetsInstructions,

--- a/src/assets/dev.ts
+++ b/src/assets/dev.ts
@@ -63,12 +63,12 @@ export async function checkHotUpdate(
   // watch web manifest changes
   if (file === assetsContext.resolvedWebManifestFile) {
     assetsContext.cache.delete(ctx.webManifestUrl);
-    return true;
+    return "webmanifest";
   }
 
   // watch pwa assets configuration file
   const result = assetsContext.sources.includes(file);
   if (result) await loadAssetsGeneratorContext(ctx, assetsContext);
 
-  return result;
+  return result ? "configuration" : undefined;
 }

--- a/src/assets/html.ts
+++ b/src/assets/html.ts
@@ -62,7 +62,6 @@ export async function resolveHtmlLinks(
   assetsContext: AssetsGeneratorContext,
 ) {
   const header = await resolveDevHtmlAssets(ctx, assetsContext);
-  console.log("header", header);
   return `export const links = ${JSON.stringify(header.link)};
 export const meta = ${JSON.stringify(header.meta)};
 `;

--- a/src/assets/html.ts
+++ b/src/assets/html.ts
@@ -62,6 +62,7 @@ export async function resolveHtmlLinks(
   assetsContext: AssetsGeneratorContext,
 ) {
   const header = await resolveDevHtmlAssets(ctx, assetsContext);
+  console.log("header", header);
   return `export const links = ${JSON.stringify(header.link)};
 export const meta = ${JSON.stringify(header.meta)};
 `;

--- a/src/assets/html.ts
+++ b/src/assets/html.ts
@@ -13,10 +13,10 @@ export async function resolveDevHtmlAssets(
   };
   if (assetsContext.includeThemeColor) {
     const manifest = await readManifestFile(ctx);
-    if (manifest && "theme_color" in manifest.manifest)
+    if (manifest && "theme_color" in manifest)
       header.meta.push({
         key: "theme-color",
-        content: manifest.manifest.theme_color,
+        content: manifest.theme_color,
         name: "theme-color",
       });
   }

--- a/src/assets/manifest.ts
+++ b/src/assets/manifest.ts
@@ -4,15 +4,9 @@ import { lstat, readFile, writeFile } from "node:fs/promises";
 import type { ImageAssetsInstructions } from "@vite-pwa/assets-generator/api";
 import { generateManifestIconsEntry } from "@vite-pwa/assets-generator/api/generate-manifest-icons-entry";
 import type { AssetsGeneratorContext } from "./types";
-import type { ResolvedConfig } from "vite";
 
-export async function readManifestFile({
-  options,
-  viteConfig,
-}: QwikPWAContext) {
-  return await readWebManifestFile(
-    resolveWebManifestFile(viteConfig, options.webManifestFilename),
-  );
+export async function readManifestFile(ctx: QwikPWAContext) {
+  return await readWebManifestFile(resolveWebManifestFile(ctx));
 }
 
 export async function injectWebManifestIcons(
@@ -50,11 +44,8 @@ export async function overrideWebManifestIcons(manifestFile: string) {
   return !!manifest?.manifest && !("icons" in manifest.manifest);
 }
 
-function resolveWebManifestFile(
-  viteConfig: ResolvedConfig,
-  manifestFile: string,
-) {
-  return resolve(viteConfig.publicDir ?? "public", manifestFile);
+function resolveWebManifestFile(ctx: QwikPWAContext) {
+  return resolve(ctx.publicDir, ctx.options.webManifestFilename);
 }
 
 async function readWebManifestFile(manifestFile: string) {

--- a/src/assets/types.ts
+++ b/src/assets/types.ts
@@ -26,7 +26,9 @@ export interface PWAAssetsGenerator {
   resolveHtmlLinks(): Promise<string>;
   resolveDevHtmlAssets(): Promise<DevHtmlAssets>;
   resolveSWPrecachingAssets(): string[];
-  checkHotUpdate(path: string): Promise<boolean>;
+  checkHotUpdate(
+    path: string,
+  ): Promise<"webmanifest" | "configuration" | undefined>;
 }
 
 export interface AssetsGeneratorContext {

--- a/src/context.ts
+++ b/src/context.ts
@@ -58,7 +58,7 @@ export function initializeContext(
     (p) => p.name === "vite-plugin-qwik-city",
   ) as QwikCityPlugin;
   ctx.target = ctx.qwikPlugin!.api.getOptions().target;
-  ctx.publicDir = viteConfig.publicDir;
+  ctx.publicDir = viteConfig.publicDir || "public";
   ctx.clientOutDir = ctx.qwikPlugin!.api.getClientOutDir()!;
   ctx.basePathRelDir = ctx
     .qwikCityPlugin!.api.getBasePathname()

--- a/src/plugins/assets.ts
+++ b/src/plugins/assets.ts
@@ -24,8 +24,7 @@ export const meta = [];
     },
     buildStart() {
       // add web manifest to watcher, and so we can reload the page when it changes
-      ctx.userOptions.overrideManifestIcons &&
-        this.addWatchFile(ctx.webManifestUrl);
+      this.addWatchFile(ctx.webManifestUrl);
     },
     async handleHotUpdate({ file, server }) {
       const assetsGenerator = await ctx.assets;

--- a/src/plugins/assets.ts
+++ b/src/plugins/assets.ts
@@ -15,7 +15,7 @@ export default function AssetsPlugin(ctx: QwikPWAContext): Plugin {
       if (id === RESOLVED_VIRTUAL) {
         const assets = await ctx.assets;
         return (
-          assets?.resolveHtmlLinks() ??
+          (await assets?.resolveHtmlLinks()) ??
           `export const links = [];
 export const meta = [];
 `

--- a/src/plugins/client.ts
+++ b/src/plugins/client.ts
@@ -24,6 +24,7 @@ export default function ClientPlugin(ctx: QwikPWAContext): Plugin {
         const routes = ctx.qwikCityPlugin.api.getRoutes();
         const swCode = await fs.readFile(ctx.swClientDistPath, "utf-8");
         const swCodeUpdate = `
+        const version = ${JSON.stringify(ctx.version)};
         const publicDirAssets = ${JSON.stringify(publicDirAssets)};
         const emittedAssets = ${JSON.stringify([
           ...generatedAssetsUrls,

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -19,7 +19,8 @@ function urlsToEntries(urls: string[], hash: string): PrecacheEntry[] {
   const matcher = /^build\/q-/;
   return urls.map((url) => {
     const match = url.match(matcher);
-    return match ? { url } : { url, revision: hash };
+    // use null revision, removing the revision or using undefined will cause workbox warnings in runtime
+    return match ? { url, revision: null } : { url, revision: hash };
   });
 }
 
@@ -32,7 +33,10 @@ function urlsToEntries(urls: string[], hash: string): PrecacheEntry[] {
  * @default "auto-update"
  */
 export function setupPwa(mode: "auto-update" | "prompt" = "auto-update") {
-  console.info(`Qwik PWA v${version}, using ${mode} strategy`);
+  if (import.meta.env.DEV) {
+    console.info(`Qwik PWA v${version}, using ${mode} strategy`);
+  }
+
   const noParamRoutes = routes.filter((r) => !r.hasParams);
   const paramRoutes = routes.filter((r) => r.hasParams);
   cleanupOutdatedCaches();
@@ -59,9 +63,11 @@ export function setupPwa(mode: "auto-update" | "prompt" = "auto-update") {
   }
 
   if (mode === "prompt") {
-    console.warn(
-      `Qwik PWA v${version}\nWARNING: "prompt" mode not available yet`,
-    );
+    if (import.meta.env.DEV) {
+      console.warn(
+        `Qwik PWA v${version}\nWARNING: "prompt" mode not available yet`,
+      );
+    }
     /*
     self.addEventListener("message", (event) => {
       if (event.data.type === "SKIP_WAITING") {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -23,7 +23,16 @@ function urlsToEntries(urls: string[], hash: string): PrecacheEntry[] {
   });
 }
 
-export function setupPwa() {
+/**
+ * Add PWA capabilities.
+ *
+ * **WARNING**: "prompt" mode not available yet.
+ *
+ * @param mode
+ * @default "auto-update"
+ */
+export function setupPwa(mode: "auto-update" | "prompt" = "auto-update") {
+  console.info(`Qwik PWA v${version}, using ${mode} strategy`);
   const noParamRoutes = routes.filter((r) => !r.hasParams);
   const paramRoutes = routes.filter((r) => r.hasParams);
   cleanupOutdatedCaches();
@@ -49,6 +58,19 @@ export function setupPwa() {
     registerRoute(route.pattern, new StaleWhileRevalidate());
   }
 
+  if (mode === "prompt") {
+    console.warn(
+      `Qwik PWA v${version}\nWARNING: "prompt" mode not available yet`,
+    );
+    /*
+    self.addEventListener("message", (event) => {
+      if (event.data.type === "SKIP_WAITING") {
+        self.skipWaiting();
+      }
+    });
+    */
+  }
+  // else {
   // Skip-Waiting Service Worker-based solution
   self.addEventListener("activate", async () => {
     // after we've taken over, iterate over all the current clients (windows)
@@ -58,8 +80,8 @@ export function setupPwa() {
       client.navigate(client.url);
     });
   });
-
   self.skipWaiting();
+  // }
 
   const base = "/build/"; // TODO: it should be dynamic based on the build
   const qprefetchEvent = new MessageEvent<ServiceWorkerMessage>("message", {
@@ -74,6 +96,7 @@ export function setupPwa() {
   self.dispatchEvent(qprefetchEvent);
 }
 
+declare const version: string;
 declare const appBundles: AppBundle[];
 
 declare const publicDirAssets: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,8 @@ export interface PWAOptions {
    *
    * With this option enabled, the plugin will add the icons entry to your web manifest file.
    *
+   * If your web manifest file already contains the icons entry, the plugin will ignore this option.
+   *
    * @default true
    */
   overrideManifestIcons?: boolean;


### PR DESCRIPTION
This PR includes:
- update typescript to `v5.3.3`
- adds `TODO.md` file with pending todos
- updates readme file to include changes in manifest.json, service-worker.ts and tsconfig.json (with diff format)
- adds initial support for `prompt` strategy: just the mode in `setupPwa`
- removes `./*` from pnpm workspace
- don't inject manifest icons when present
- refactor manifest module to include id, scope and icons when required in the web manifest (included also a warning when `color_theme` missing)
- refactor assets plugin to handle configuration changes properly (custom pwa assets configuration file)
- added `.npmrc` with `shell-emulator=true` to test custom pwa assets configuration file changes: added the file and script (`dev.custom`) to run the test